### PR TITLE
update mongo connection string with proper mongo host during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /usr/src/app
 
 COPY . .
 
+RUN sed -i "s/mongodb:\/\/localhost/mongodb:\/\/mongo/g" common/services/mongoose.service.js
+
 RUN npm install
 
 EXPOSE 3600


### PR DESCRIPTION
"docker-compose up" doesn't really work, because the API is trying to connect to MongoDB at localhost. I added a script to update the connection string to look for host "mongo" when run in docker containers.